### PR TITLE
Update crash-offsets.md

### DIFF
--- a/docs/fl-binaries/crash-offsets.md
+++ b/docs/fl-binaries/crash-offsets.md
@@ -91,6 +91,7 @@ If you're using the event viewer for this a lot, you can use the following xml f
 | server.dll | 702064 | Laz             | Triggered by warping to a base that doesn't have a physical presence, but has an mbase and universe entry           |
 | server.dll | 2247f  | Ruppetthemuppet | NPC loadout is missing engine.  Attempts to enter cruise, then can't find and crashes.                              |
 | server.dll | 0f988  | Ruppetthemuppet | Missing destination jumpgate                                                                                        |
+| server.dll | 1b221  | HeIIoween       | More than 10 holes/gates per System                                                                                 |
 
 
 ### Miscellaneous


### PR DESCRIPTION
From HLHook's CrashCatcer.cpp:
"This crash will happen if you have broken path finding or more than 10 connections per system."