### PR TITLE
Update community-info.md by fixing broken link of FLCombinedPatch.exe

### DIFF
--- a/docs/community-info.md
+++ b/docs/community-info.md
@@ -34,7 +34,7 @@ SHA512: 1ad4482d3cf48d6f408f16360c5f41d20bbda3aa46d0e1be6edc7e68c4be097a0eb8063e
 
 ## Vanilla Patch (Combined 1.1, JFLP, No-CD) - Option 2
 
-1. Download the self extracting zip: https://cdn.discordapp.com/attachments/661329208609603617/752174852722393169/FLCombinedPatch.exe
+1. Download the self extracting zip: https://mega.nz/file/mQt0kbzC#4GWIedKYjbkZcj2BKYpun8SinMQpflaiVkt5knk3AO0
 2. Extract to your Freelancer installation e.g. **C:\Program Files (x86)\Microsoft Games\Freelancer** 
 
 :::caution


### PR DESCRIPTION
Discord link https://cdn.discordapp.com/attachments/661329208609603617/752174852722393169/FLCombinedPatch.exe gives: This content is no longer available.

Proper link from https://the-starport.com/forums/topic/6250/how-to-get-vanilla-freelancer-running-in-2023-no-cd by Raikkonen works!